### PR TITLE
Switched mhash() to hash() in formBuilder

### DIFF
--- a/src/modules/form/fieldBuilder.php
+++ b/src/modules/form/fieldBuilder.php
@@ -270,7 +270,7 @@ class fieldBuilder{
 				$time = new time;
 				return $time->toSeconds($value);
 			case 'password':
-				return mhash($this->hash, $value);
+				return hash($this->hash, $value);
 			default:
 				return $value;
 		}


### PR DESCRIPTION
mhash() has been removed from PHP 5.3 in favor of hash()
